### PR TITLE
Set CameraViewController task to imageCapture

### DIFF
--- a/src/ios/CDVImageCapture.m
+++ b/src/ios/CDVImageCapture.m
@@ -69,6 +69,7 @@
         cameraViewController.flashModeValue = AVCaptureFlashModeAuto;
     }
     cameraViewController.mediaStreamInterface = self;
+    cameraViewController.task = @"imageCapture";
     [weakSelf.viewController presentViewController:cameraViewController animated:YES completion:^{
         weakSelf.hasPendingOperation = NO;
     }];


### PR DESCRIPTION

## Description
CameraViewController task is null, so takePhoto doesn't work.
Setting the task to "imageCapture" fixed it. 

This closes #26 
## Related Issue
#26


## Motivation and Context
Because takePhoto is not working, it crashes as explained on #26

## How Has This Been Tested?
Tested on a real device after the code change on the plugin

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
