### PR TITLE
Fix imageCapture.takePhoto() on iOS 9

### DIFF
--- a/www/ImageCapture.js
+++ b/www/ImageCapture.js
@@ -50,7 +50,7 @@ ImageCapture.prototype.takePhoto = function (photoSettings) {
                     .catch(function () {
                     });
             } else {
-                var byteCharacters = atob(info); // eslint-disable-line no-undef
+                var byteCharacters = atob(info.replace(/\s/g, '')); // eslint-disable-line no-undef
                 var byteNumbers = new Array(byteCharacters.length);
                 for (var i = 0; i < byteCharacters.length; i++) {
                     byteNumbers[i] = byteCharacters.charCodeAt(i);

--- a/www/ImageCapture.js
+++ b/www/ImageCapture.js
@@ -50,13 +50,21 @@ ImageCapture.prototype.takePhoto = function (photoSettings) {
                     .catch(function () {
                     });
             } else {
+                var sliceSize = 1024;
                 var byteCharacters = atob(info.replace(/\s/g, '')); // eslint-disable-line no-undef
-                var byteNumbers = new Array(byteCharacters.length);
-                for (var i = 0; i < byteCharacters.length; i++) {
-                    byteNumbers[i] = byteCharacters.charCodeAt(i);
+                var bytesLength = byteCharacters.length;
+                var slicesCount = Math.ceil(bytesLength / sliceSize);
+                var byteArrays = new Array(slicesCount);
+                for (var sliceIndex = 0; sliceIndex < slicesCount; ++sliceIndex) {
+                    var begin = sliceIndex * sliceSize;
+                    var end = Math.min(begin + sliceSize, bytesLength);
+                    var bytes = new Array(end - begin);
+                    for (var offset = begin, i = 0; offset < end; ++i, ++offset) {
+                        bytes[i] = byteCharacters[offset].charCodeAt(0);
+                    }
+                    byteArrays[sliceIndex] = new Uint8Array(bytes);
                 }
-                var byteArray = new Uint8Array(byteNumbers);
-                var blob = new Blob([byteArray], { // eslint-disable-line no-undef
+                var blob = new Blob(byteArrays, { // eslint-disable-line no-undef
                     type: 'image/png'
                 });
                 resolve(blob);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See #31 and #32 

## Related Issue
See #31 and #32 

## Motivation and Context
imageCapture.takePhoto() wasn't working on iOS 9 because of 2 problems

## How Has This Been Tested?
ran the test, ran the app on a real iOS 9 device

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
